### PR TITLE
Unescape multiline messages

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.2.2
+- Unescape messages before building the id to match [the extractor behaviour](https://github.com/cca-io/rescript-react-intl-extractor/pull/83/files#diff-a536227426c32f9d1022eec01c9cc69ec7ef6ded0c3027bebd72b61f84fbe444R17)
+
 ## 0.2.1
 - Make intlConfig accept Js.Exn.t as onError parameter
 

--- a/ppx/Resolver.re
+++ b/ppx/Resolver.re
@@ -83,9 +83,14 @@ let parsePayload = (~loc, payload) =>
 let makeId = (~description="", message) =>
   message ++ "|" ++ description |> Digest.string |> Digest.to_hex;
 
+let tryUnescape = s =>
+  try(Scanf.unescaped(s)) {
+  | Scanf.Scan_failure(_err) => s
+  };
+
 let makeIntlRecord = (~payload, ~loc) => {
   let (message, messageExp, description) = parsePayload(~loc, payload);
-  let id = message |> Scanf.unescaped |> makeId(~description?);
+  let id = message |> tryUnescape |> makeId(~description?);
   let idExp = Ast_helper.Exp.constant(Pconst_string(id, loc, None));
   %expr
   [@warning "-45"]

--- a/ppx/Resolver.re
+++ b/ppx/Resolver.re
@@ -85,7 +85,7 @@ let makeId = (~description="", message) =>
 
 let makeIntlRecord = (~payload, ~loc) => {
   let (message, messageExp, description) = parsePayload(~loc, payload);
-  let id = makeId(~description?, message);
+  let id = message |> Scanf.unescaped |> makeId(~description?);
   let idExp = Ast_helper.Exp.constant(Pconst_string(id, loc, None));
   %expr
   [@warning "-45"]


### PR DESCRIPTION
Unescape messages before building the id to match [the extractor behaviour](https://github.com/cca-io/rescript-react-intl-extractor/pull/83/files#diff-a536227426c32f9d1022eec01c9cc69ec7ef6ded0c3027bebd72b61f84fbe444R17)