### PR TITLE
Add list_of_values in the ppx as labelled argument

### DIFF
--- a/lib/ReactIntl.re
+++ b/lib/ReactIntl.re
@@ -7,8 +7,8 @@ external dateTimeFormatOptions:
     ~formatMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `basic]=?,
     ~timeZone: string=?,
     ~hour12: bool=?,
-    ~weekday:  [ | `narrow | `short | `long]=?,
-    ~era:  [ | `narrow | `short | `long]=?,
+    ~weekday: [ | `narrow | `short | `long]=?,
+    ~era: [ | `narrow | `short | `long]=?,
     ~year: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
     ~month: [@mel.string] [
               | `numeric
@@ -33,8 +33,8 @@ type relativeTimeFormatOptions;
 [@mel.obj]
 external relativeTimeFormatOptions:
   (
-    ~numeric:  [ | `always | `auto]=?,
-    ~style:  [ | `long | `short | `narrow]=?,
+    ~numeric: [ | `always | `auto]=?,
+    ~style: [ | `long | `short | `narrow]=?,
     ~format: string=?,
     unit
   ) =>
@@ -46,9 +46,9 @@ type numberFormatOptions;
 external numberFormatOptions:
   (
     ~localeMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `lookup]=?,
-    ~style:  [ | `decimal | `currency | `percent]=?,
+    ~style: [ | `decimal | `currency | `percent]=?,
     ~currency: string=?,
-    ~currencyDisplay:  [ | `symbol | `code | `name]=?,
+    ~currencyDisplay: [ | `symbol | `code | `name]=?,
     ~useGrouping: bool=?,
     ~minimumIntegerDigits: int=?,
     ~minimumFractionDigits: int=?,
@@ -63,16 +63,15 @@ type pluralFormatOptions;
 
 [@mel.obj]
 external pluralFormatOptions:
-  (~style:  [ | `cardinal | `ordinal]=?, unit) =>
-  pluralFormatOptions;
+  (~style: [ | `cardinal | `ordinal]=?, unit) => pluralFormatOptions;
 
 type listFormatOptions;
 
 [@mel.obj]
 external listFormatOptions:
   (
-    ~style:  [ | `long | `short | `narrow]=?,
-    ~_type:  [ | `disjunction | `conjunction | `unit]=?,
+    ~style: [ | `long | `short | `narrow]=?,
+    ~_type: [ | `disjunction | `conjunction | `unit]=?,
     unit
   ) =>
   listFormatOptions;
@@ -82,9 +81,9 @@ type displayNameFormatOptions;
 [@mel.obj]
 external displayNameFormatOptions:
   (
-    ~style:  [ | `long | `short | `narrow]=?,
-    ~_type:  [ | `language | `region | `script | `currency]=?,
-    ~fallback:  [ | `code | `none]=?,
+    ~style: [ | `long | `short | `narrow]=?,
+    ~_type: [ | `language | `region | `script | `currency]=?,
+    ~fallback: [ | `code | `none]=?,
     unit
   ) =>
   displayNameFormatOptions;
@@ -93,6 +92,15 @@ type message = {
   id: string,
   defaultMessage: string,
 };
+
+/* The kinds of values that instances of [%intl.s ""] or [%intl.el ""] can be. It's only used in the native runtime, and not used by the melange bindings. */
+type value = [
+  | `String(string) /* {"name": "Yuri"} */
+  | `Number(int) /* {"number": 1} */
+  | `Element(React.element) /* {"icon": <Icon symbol={js|𝄤|js} color=`orange fontFamily=AhrefsDisplay />} */
+  | `Component(string => React.element) /* {"a": id => <a href=AhrefsUrls.pricing> id </a> */
+  /* Note: Element is a static element, while Component has access to children */
+];
 
 type part = {
   [@mel.as "type"]
@@ -141,16 +149,7 @@ module Intl = {
     (
       t,
       float,
-       [
-        | `second
-        | `minute
-        | `hour
-        | `day
-        | `week
-        | `month
-        | `quarter
-        | `year
-      ]
+      [ | `second | `minute | `hour | `day | `week | `month | `quarter | `year]
     ) =>
     string =
     "formatRelativeTime";
@@ -159,7 +158,7 @@ module Intl = {
     (
       t,
       float,
-       [
+      [
         | `second
         | `minute
         | `hour
@@ -192,7 +191,8 @@ module Intl = {
   [@mel.send]
   external formatMessageWithValues: (t, message, Js.t({..})) => string =
     "formatMessage";
-  [@mel.send] external formatList: (t, array(string)) => string = "formatList";
+  [@mel.send]
+  external formatList: (t, array(string)) => string = "formatList";
   [@mel.send]
   external formatListWithOptions:
     (t, array(string), listFormatOptions) => string =
@@ -284,13 +284,17 @@ module FormattedDate = {
   external make:
     (
       ~value: Js.Date.t,
-      ~localeMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `lookup]
+      ~localeMatcher: [@mel.string] [
+                        | [@mel.as "best fit"] `bestFit
+                        | `lookup
+                      ]
                         =?,
-      ~formatMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `basic]=?,
+      ~formatMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `basic]
+                        =?,
       ~timeZone: string=?,
       ~hour12: bool=?,
-      ~weekday:  [ | `narrow | `short | `long]=?,
-      ~era:  [ | `narrow | `short | `long]=?,
+      ~weekday: [ | `narrow | `short | `long]=?,
+      ~era: [ | `narrow | `short | `long]=?,
       ~year: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~month: [@mel.string] [
                 | `numeric
@@ -304,7 +308,7 @@ module FormattedDate = {
       ~hour: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~minute: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~second: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
-      ~timeZoneName:  [ | `short | `long]=?,
+      ~timeZoneName: [ | `short | `long]=?,
       ~format: string=?,
       ~children: (~formattedDate: string) => React.element=?
     ) =>
@@ -317,13 +321,17 @@ module FormattedDateParts = {
   external make:
     (
       ~value: Js.Date.t,
-      ~localeMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `lookup]
+      ~localeMatcher: [@mel.string] [
+                        | [@mel.as "best fit"] `bestFit
+                        | `lookup
+                      ]
                         =?,
-      ~formatMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `basic]=?,
+      ~formatMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `basic]
+                        =?,
       ~timeZone: string=?,
       ~hour12: bool=?,
-      ~weekday:  [ | `narrow | `short | `long]=?,
-      ~era:  [ | `narrow | `short | `long]=?,
+      ~weekday: [ | `narrow | `short | `long]=?,
+      ~era: [ | `narrow | `short | `long]=?,
       ~year: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~month: [@mel.string] [
                 | `numeric
@@ -337,7 +345,7 @@ module FormattedDateParts = {
       ~hour: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~minute: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~second: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
-      ~timeZoneName:  [ | `short | `long]=?,
+      ~timeZoneName: [ | `short | `long]=?,
       ~format: string=?,
       ~children: (~formattedDateParts: array(part)) => React.element
     ) =>
@@ -350,13 +358,17 @@ module FormattedTime = {
   external make:
     (
       ~value: Js.Date.t,
-      ~localeMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `lookup]
+      ~localeMatcher: [@mel.string] [
+                        | [@mel.as "best fit"] `bestFit
+                        | `lookup
+                      ]
                         =?,
-      ~formatMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `basic]=?,
+      ~formatMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `basic]
+                        =?,
       ~timeZone: string=?,
       ~hour12: bool=?,
-      ~weekday:  [ | `narrow | `short | `long]=?,
-      ~era:  [ | `narrow | `short | `long]=?,
+      ~weekday: [ | `narrow | `short | `long]=?,
+      ~era: [ | `narrow | `short | `long]=?,
       ~year: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~month: [@mel.string] [
                 | `numeric
@@ -370,7 +382,7 @@ module FormattedTime = {
       ~hour: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~minute: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~second: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
-      ~timeZoneName:  [ | `short | `long]=?,
+      ~timeZoneName: [ | `short | `long]=?,
       ~format: string=?,
       ~children: (~formattedTime: string) => React.element=?
     ) =>
@@ -383,13 +395,17 @@ module FormattedTimeParts = {
   external make:
     (
       ~value: Js.Date.t,
-      ~localeMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `lookup]
+      ~localeMatcher: [@mel.string] [
+                        | [@mel.as "best fit"] `bestFit
+                        | `lookup
+                      ]
                         =?,
-      ~formatMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `basic]=?,
+      ~formatMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `basic]
+                        =?,
       ~timeZone: string=?,
       ~hour12: bool=?,
-      ~weekday:  [ | `narrow | `short | `long]=?,
-      ~era:  [ | `narrow | `short | `long]=?,
+      ~weekday: [ | `narrow | `short | `long]=?,
+      ~era: [ | `narrow | `short | `long]=?,
       ~year: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~month: [@mel.string] [
                 | `numeric
@@ -403,7 +419,7 @@ module FormattedTimeParts = {
       ~hour: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~minute: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
       ~second: [@mel.string] [ | `numeric | [@mel.as "2-digit"] `twoDigit]=?,
-      ~timeZoneName:  [ | `short | `long]=?,
+      ~timeZoneName: [ | `short | `long]=?,
       ~format: string=?,
       ~children: (~formattedTimeParts: array(part)) => React.element
     ) =>
@@ -416,7 +432,7 @@ module FormattedRelativeTime = {
   external make:
     (
       ~value: float,
-      ~unit:  [
+      ~unit: [
                | `second
                | `minute
                | `hour
@@ -427,8 +443,8 @@ module FormattedRelativeTime = {
                | `year
              ]
                =?,
-      ~numeric:  [ | `always | `auto]=?,
-      ~style:  [ | `long | `short | `narrow]=?,
+      ~numeric: [ | `always | `auto]=?,
+      ~style: [ | `long | `short | `narrow]=?,
       ~format: string=?,
       ~updateIntervalInSeconds: float=?,
       ~children: (~formattedDate: string) => React.element=?
@@ -442,11 +458,14 @@ module FormattedNumber = {
   external make:
     (
       ~value: float,
-      ~localeMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `lookup]
+      ~localeMatcher: [@mel.string] [
+                        | [@mel.as "best fit"] `bestFit
+                        | `lookup
+                      ]
                         =?,
-      ~style:  [ | `decimal | `currency | `percent]=?,
+      ~style: [ | `decimal | `currency | `percent]=?,
       ~currency: string=?,
-      ~currencyDisplay:  [ | `symbol | `code | `name]=?,
+      ~currencyDisplay: [ | `symbol | `code | `name]=?,
       ~useGrouping: bool=?,
       ~minimumIntegerDigits: int=?,
       ~minimumFractionDigits: int=?,
@@ -465,11 +484,14 @@ module FormattedNumberParts = {
   external make:
     (
       ~value: float,
-      ~localeMatcher: [@mel.string] [ | [@mel.as "best fit"] `bestFit | `lookup]
+      ~localeMatcher: [@mel.string] [
+                        | [@mel.as "best fit"] `bestFit
+                        | `lookup
+                      ]
                         =?,
-      ~style:  [ | `decimal | `currency | `percent]=?,
+      ~style: [ | `decimal | `currency | `percent]=?,
       ~currency: string=?,
-      ~currencyDisplay:  [ | `symbol | `code | `name]=?,
+      ~currencyDisplay: [ | `symbol | `code | `name]=?,
       ~useGrouping: bool=?,
       ~minimumIntegerDigits: int=?,
       ~minimumFractionDigits: int=?,
@@ -488,7 +510,7 @@ module FormattedPlural = {
   external make:
     (
       ~value: int,
-      ~style:  [ | `cardinal | `ordinal]=?,
+      ~style: [ | `cardinal | `ordinal]=?,
       ~other: React.element,
       ~zero: React.element=?,
       ~one: React.element=?,
@@ -506,8 +528,8 @@ module FormattedList = {
   external make:
     (
       ~value: array(string),
-      ~style:  [ | `long | `short | `narrow]=?,
-      ~_type:  [ | `disjunction | `conjunction | `unit]=?,
+      ~style: [ | `long | `short | `narrow]=?,
+      ~_type: [ | `disjunction | `conjunction | `unit]=?,
       ~children: (~formattedList: string) => React.element=?
     ) =>
     React.element =
@@ -519,9 +541,9 @@ module FormattedDisplayName = {
   external make:
     (
       ~value: string,
-      ~style:  [ | `long | `short | `narrow]=?,
-      ~_type:  [ | `language | `region | `script | `currency]=?,
-      ~fallback:  [ | `code | `none]=?
+      ~style: [ | `long | `short | `narrow]=?,
+      ~_type: [ | `language | `region | `script | `currency]=?,
+      ~fallback: [ | `code | `none]=?
     ) =>
     React.element =
     "FormattedDisplayName";

--- a/ppx/Resolver.re
+++ b/ppx/Resolver.re
@@ -129,10 +129,11 @@ let makeString = (~loc, message, messageExp, description) => {
     ReactIntlPpxAdaptor.Message.to_s([%e recordExp])
   | variables =>
     let valuesType = variables |> makeValuesType(~loc);
+    let list_of_values = variables |> makeValuesAsList(~loc);
     %expr
     (
       (values: Js.t([%t valuesType])) => (
-        ReactIntlPpxAdaptor.Message.format_to_s([%e recordExp], values): string
+        ReactIntlPpxAdaptor.Message.format_to_s(~list_of_values=[%e list_of_values], [%e recordExp], values): string
       )
     );
   };
@@ -161,11 +162,12 @@ let makeReactElement = (~loc, message, messageExp, description) => {
     React.string(ReactIntlPpxAdaptor.Message.to_s([%e recordExp]))
   | variables =>
     let valuesType = variables |> makeValuesType(~loc);
+    let list_of_values = variables |> makeValuesAsList(~loc);
     %expr
     (
       (values: Js.t([%t valuesType])) =>
         React.string(
-          ReactIntlPpxAdaptor.Message.format_to_s([%e recordExp], values)
+          ReactIntlPpxAdaptor.Message.format_to_s(~list_of_values=[%e list_of_values], [%e recordExp], values)
         )
     );
   };

--- a/ppx/Resolver.re
+++ b/ppx/Resolver.re
@@ -176,14 +176,14 @@ let makeReactElement = (~loc, message, messageExp, description) => {
     let list_of_values = variables |> makeValuesAsList(~loc);
     [%expr
      (
-       (values: Js.t([%t valuesType])) =>
-         React.string(
-           ReactIntlPpxAdaptor.Message.format_to_s(
+       (
+         (values: Js.t([%t valuesType])) =>
+           ReactIntlPpxAdaptor.Message.format_to_el(
              ~list_of_values=[%e list_of_values],
              [%e recordExp],
              values,
-           ),
-         )
+           )
+       ): React.element
      )];
   };
 };

--- a/ppx/Resolver.re
+++ b/ppx/Resolver.re
@@ -123,17 +123,20 @@ let makeValuesAsList = (~loc, variables) => {
            );
          let value =
            switch (type_.ptyp_desc) {
-           | Ptyp_constr({txt: Lident("string")}, []) =>
+           | Ptyp_constr({txt: Lident("string"), _}, []) =>
              [%expr `String([%e access_values_object])]
-           | Ptyp_constr({txt: Lident("int")}, []) =>
+           | Ptyp_constr({txt: Lident("int"), _}, []) =>
              [%expr `Number([%e access_values_object])]
-           | Ptyp_constr({txt: Ldot(Lident("React"), "element")}, []) =>
+           | Ptyp_constr({txt: Ldot(Lident("React"), "element"), _}, []) =>
              [%expr `Element([%e access_values_object])]
            | Ptyp_arrow(_, core_type_arg, core_type_return) =>
              switch (core_type_arg.ptyp_desc, core_type_return.ptyp_desc) {
              | (
-                 Ptyp_constr({txt: Lident("string")}, []),
-                 Ptyp_constr({txt: Ldot(Lident("React"), "element")}, []),
+                 Ptyp_constr({txt: Lident("string"), _}, []),
+                 Ptyp_constr(
+                   {txt: Ldot(Lident("React"), "element"), _},
+                   [],
+                 ),
                ) =>
                [%expr `Component([%e access_values_object])]
              | _ =>

--- a/ppx/Resolver.re
+++ b/ppx/Resolver.re
@@ -176,14 +176,12 @@ let makeReactElement = (~loc, message, messageExp, description) => {
     let list_of_values = variables |> makeValuesAsList(~loc);
     [%expr
      (
-       (
-         (values: Js.t([%t valuesType])) =>
-           ReactIntlPpxAdaptor.Message.format_to_el(
-             ~list_of_values=[%e list_of_values],
-             [%e recordExp],
-             values,
-           )
-       ): React.element
+       (values: Js.t([%t valuesType])) =>
+         ReactIntlPpxAdaptor.Message.format_to_el(
+           ~list_of_values=[%e list_of_values],
+           [%e recordExp],
+           values,
+         )
      )];
   };
 };

--- a/test/Test.re
+++ b/test/Test.re
@@ -8,7 +8,14 @@ module ReactIntl = {
 module ReactIntlPpxAdaptor = {
   module Message = {
     let to_s = (message: ReactIntl.message): string => message.defaultMessage;
-    let format_to_s = (message: ReactIntl.message, _values: Js.t({..})): string => message.defaultMessage;
+    let format_to_s =
+        (
+          ~list_of_values as _,
+          message: ReactIntl.message,
+          _values: Js.t({..}),
+        )
+        : string =>
+      message.defaultMessage;
   };
 };
 
@@ -32,12 +39,22 @@ let descriptedElement3: React.element = [%intl.el
   {msg: "i am message", desc: "i am description"}
 ];
 
-let stringWithVariable: ({. "variable": string} => string) = [%intl.s "I am string with {variable}"];
+let stringWithVariable: {. "variable": string} => string = [%intl.s
+  "I am string with {variable}"
+];
 
-let stringWithPluralForm: ({. "itemsCount": int} => string) = [%intl.s "{itemsCount, plural, zero {item} one {item} few {items} many {items} other {items}}"];
+let stringWithPluralForm: {. "itemsCount": int} => string = [%intl.s
+  "{itemsCount, plural, zero {item} one {item} few {items} many {items} other {items}}"
+];
 
-let elementWithVariable: ({. "variable": React.element} => React.element) = [%intl.el "I am react element with {variable}"];
+let elementWithVariable: {. "variable": React.element} => React.element = [%intl.el
+  "I am react element with {variable}"
+];
 
-let elementWithPluralForm: ({. "itemsCount": int} => React.element) = [%intl.el "{itemsCount, plural, zero {item} one {item} few {items} many {items} other {items}}"];
+let elementWithPluralForm: {. "itemsCount": int} => React.element = [%intl.el
+  "{itemsCount, plural, zero {item} one {item} few {items} many {items} other {items}}"
+];
 
-let elementWithRichText: ({. "a": string => React.element} => React.element) = [%intl.el "Some text with <a>link text</a>"];
+let elementWithRichText: {. "a": string => React.element} => React.element = [%intl.el
+  "Some text with <a>link text</a>"
+];

--- a/test/Test.re
+++ b/test/Test.re
@@ -1,16 +1,9 @@
-module ReactIntl = {
-  type message = {
-    id: string,
-    defaultMessage: string,
-  };
-};
-
 module ReactIntlPpxAdaptor = {
   module Message = {
     let to_s = (message: ReactIntl.message): string => message.defaultMessage;
     let format_to_s =
         (
-          ~list_of_values as _,
+          ~list_of_values as _: list((string, ReactIntl.value)),
           message: ReactIntl.message,
           _values: Js.t({..}),
         )
@@ -18,18 +11,13 @@ module ReactIntlPpxAdaptor = {
       message.defaultMessage;
     let format_to_el =
         (
-          ~list_of_values as _,
+          ~list_of_values as _: list((string, ReactIntl.value)),
           message: ReactIntl.message,
           _values: Js.t({..}),
         )
         : React.element =>
       React.string(message.defaultMessage);
   };
-};
-
-module React = {
-  type element;
-  external string: string => element = "%identity";
 };
 
 let message: ReactIntl.message = [%intl "i am message"];

--- a/test/Test.re
+++ b/test/Test.re
@@ -16,6 +16,14 @@ module ReactIntlPpxAdaptor = {
         )
         : string =>
       message.defaultMessage;
+    let format_to_el =
+        (
+          ~list_of_values as _,
+          message: ReactIntl.message,
+          _values: Js.t({..}),
+        )
+        : React.element =>
+      React.string(message.defaultMessage);
   };
 };
 

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (melange.emit
  (target test)
- (libraries melange-react-intl.lib)
+ (libraries melange-react-intl.lib reason-react)
  (preprocess
   (pps melange.ppx melange-react-intl.ppx)))

--- a/test/ppx/params.t
+++ b/test/ppx/params.t
@@ -45,10 +45,8 @@ With plural
       ) => (
         ReactIntlPpxAdaptor.Message.format_to_s(
           ~list_of_values=[
-            (
-              ("listName", `String(values##listName)),
-              ("keywordsCount", `Number(values##keywordsCount)),
-            ),
+            ("listName", `String(values##listName)),
+            ("keywordsCount", `Number(values##keywordsCount)),
           ],
           [@warning "-45"]
           ReactIntl.{

--- a/test/ppx/params.t
+++ b/test/ppx/params.t
@@ -15,7 +15,7 @@ Basic case
           defaultMessage: {js|{maxLength} characters maximum|js},
         },
         values,
-      ): React.element
+      )
   ) @@
   {"maxLength": length->NumFormat.Int.format->RR.s};
 

--- a/test/ppx/params.t
+++ b/test/ppx/params.t
@@ -9,6 +9,7 @@ Basic case
     (values: {. "maxLength": React.element}) =>
       React.string(
         ReactIntlPpxAdaptor.Message.format_to_s(
+          ~list_of_values=[("maxLength", `Element(values##maxLength))],
           [@warning "-45"]
           ReactIntl.{
             id: "52d92c9e4920f7e245381fad58360708",

--- a/test/ppx/params.t
+++ b/test/ppx/params.t
@@ -7,17 +7,15 @@ Basic case
   $ ./ppx.sh --output re input.re
   (
     (values: {. "maxLength": React.element}) =>
-      React.string(
-        ReactIntlPpxAdaptor.Message.format_to_s(
-          ~list_of_values=[("maxLength", `Element(values##maxLength))],
-          [@warning "-45"]
-          ReactIntl.{
-            id: "52d92c9e4920f7e245381fad58360708",
-            defaultMessage: {js|{maxLength} characters maximum|js},
-          },
-          values,
-        ),
-      )
+      ReactIntlPpxAdaptor.Message.format_to_el(
+        ~list_of_values=[("maxLength", `Element(values##maxLength))],
+        [@warning "-45"]
+        ReactIntl.{
+          id: "52d92c9e4920f7e245381fad58360708",
+          defaultMessage: {js|{maxLength} characters maximum|js},
+        },
+        values,
+      ): React.element
   ) @@
   {"maxLength": length->NumFormat.Int.format->RR.s};
 

--- a/test/ppx/simple.t/input.re
+++ b/test/ppx/simple.t/input.re
@@ -1,29 +1,3 @@
-module ReactIntl = {
-  type message = {
-    id: string,
-    defaultMessage: string,
-  };
-};
-
-module ReactIntlPpxAdaptor = {
-  module Message = {
-    let to_s = (message: ReactIntl.message): string => message.defaultMessage;
-    let format_to_s =
-        (
-          ~list_of_values as _,
-          message: ReactIntl.message,
-          _values: Js.t({..}),
-        )
-        : string =>
-      message.defaultMessage;
-  };
-};
-
-module React = {
-  type element;
-  external string: string => element = "%identity";
-};
-
 let message: ReactIntl.message = [%intl "i am message"];
 let descriptedMessage: ReactIntl.message = [%intl
   {msg: "i am message", desc: "i am description"}

--- a/test/ppx/simple.t/run.t
+++ b/test/ppx/simple.t/run.t
@@ -71,7 +71,7 @@
         values,
       ): string
     );
-  let elementWithVariable: {. "variable": React.element} => React.element = (
+  let elementWithVariable: {. "variable": React.element} => React.element =
     (values: {. "variable": React.element}) =>
       ReactIntlPpxAdaptor.Message.format_to_el(
         ~list_of_values=[("variable", `Element(values##variable))],
@@ -81,9 +81,8 @@
           defaultMessage: "I am react element with {variable}",
         },
         values,
-      ): React.element
-  );
-  let elementWithPluralForm: {. "itemsCount": int} => React.element = (
+      );
+  let elementWithPluralForm: {. "itemsCount": int} => React.element =
     (values: {. "itemsCount": int}) =>
       ReactIntlPpxAdaptor.Message.format_to_el(
         ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
@@ -93,9 +92,8 @@
           defaultMessage: "{itemsCount, plural, zero {item} one {item} few {items} many {items} other {items}}",
         },
         values,
-      ): React.element
-  );
-  let elementWithRichText: {. "a": string => React.element} => React.element = (
+      );
+  let elementWithRichText: {. "a": string => React.element} => React.element =
     (values: {. "a": string => React.element}) =>
       ReactIntlPpxAdaptor.Message.format_to_el(
         ~list_of_values=[("a", `Component(values##a))],
@@ -105,8 +103,7 @@
           defaultMessage: "Some text with <a>link text</a>",
         },
         values,
-      ): React.element
-  );
+      );
   let cellText = (~powerUsersCount) =>
     (
       (
@@ -127,7 +124,7 @@
             defaultMessage: {js|{powerUsersCountString} {powerUsersCount, plural, zero {Power users} one {Power user} few {Power users} other {Power users}}|js},
           },
           values,
-        ): React.element
+        )
     ) @@
     {
       "powerUsersCountString": powerUsersCount->RR.int,

--- a/test/ppx/simple.t/run.t
+++ b/test/ppx/simple.t/run.t
@@ -73,6 +73,7 @@
   let stringWithVariable: {. "variable": string} => string =
     (values: {. "variable": string}) => (
       ReactIntlPpxAdaptor.Message.format_to_s(
+        ~list_of_values=[("variable", `String(values##variable))],
         [@warning "-45"]
         ReactIntl.{
           id: "4271c9d35b2eac4fca6faf3e2eeb6019",
@@ -84,6 +85,7 @@
   let stringWithPluralForm: {. "itemsCount": int} => string =
     (values: {. "itemsCount": int}) => (
       ReactIntlPpxAdaptor.Message.format_to_s(
+        ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
         [@warning "-45"]
         ReactIntl.{
           id: "a2926a901acebbdc606104ceae81dc82",
@@ -96,6 +98,7 @@
     (values: {. "variable": React.element}) =>
       React.string(
         ReactIntlPpxAdaptor.Message.format_to_s(
+          ~list_of_values=[("variable", `Element(values##variable))],
           [@warning "-45"]
           ReactIntl.{
             id: "ac400e3c977990cd86a6981ad7eef8cd",
@@ -108,6 +111,7 @@
     (values: {. "itemsCount": int}) =>
       React.string(
         ReactIntlPpxAdaptor.Message.format_to_s(
+          ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
           [@warning "-45"]
           ReactIntl.{
             id: "a2926a901acebbdc606104ceae81dc82",
@@ -120,6 +124,7 @@
     (values: {. "a": string => React.element}) =>
       React.string(
         ReactIntlPpxAdaptor.Message.format_to_s(
+          ~list_of_values=[("a", `Component(values##a))],
           [@warning "-45"]
           ReactIntl.{
             id: "c1d9f720d6a89b19f574a7de2bf55f62",

--- a/test/ppx/simple.t/run.t
+++ b/test/ppx/simple.t/run.t
@@ -146,12 +146,10 @@
           ReactIntlPpxAdaptor.Message.format_to_s(
             ~list_of_values=[
               (
-                (
-                  "powerUsersCountString",
-                  `Element(values##powerUsersCountString),
-                ),
-                ("powerUsersCount", `Number(values##powerUsersCount)),
+                "powerUsersCountString",
+                `Element(values##powerUsersCountString),
               ),
+              ("powerUsersCount", `Number(values##powerUsersCount)),
             ],
             [@warning "-45"]
             ReactIntl.{

--- a/test/ppx/simple.t/run.t
+++ b/test/ppx/simple.t/run.t
@@ -1,27 +1,4 @@
   $ ../ppx.sh --output re input.re
-  module ReactIntl = {
-    type message = {
-      id: string,
-      defaultMessage: string,
-    };
-  };
-  module ReactIntlPpxAdaptor = {
-    module Message = {
-      let to_s = (message: ReactIntl.message): string => message.defaultMessage;
-      let format_to_s =
-          (
-            ~list_of_values as _,
-            message: ReactIntl.message,
-            _values: Js.t({..}),
-          )
-          : string =>
-        message.defaultMessage;
-    };
-  };
-  module React = {
-    type element;
-    external string: string => element = "%identity";
-  };
   let message: ReactIntl.message =
     [@warning "-45"]
     ReactIntl.{

--- a/test/ppx/simple.t/run.t
+++ b/test/ppx/simple.t/run.t
@@ -94,45 +94,42 @@
         values,
       ): string
     );
-  let elementWithVariable: {. "variable": React.element} => React.element =
+  let elementWithVariable: {. "variable": React.element} => React.element = (
     (values: {. "variable": React.element}) =>
-      React.string(
-        ReactIntlPpxAdaptor.Message.format_to_s(
-          ~list_of_values=[("variable", `Element(values##variable))],
-          [@warning "-45"]
-          ReactIntl.{
-            id: "ac400e3c977990cd86a6981ad7eef8cd",
-            defaultMessage: "I am react element with {variable}",
-          },
-          values,
-        ),
-      );
-  let elementWithPluralForm: {. "itemsCount": int} => React.element =
+      ReactIntlPpxAdaptor.Message.format_to_el(
+        ~list_of_values=[("variable", `Element(values##variable))],
+        [@warning "-45"]
+        ReactIntl.{
+          id: "ac400e3c977990cd86a6981ad7eef8cd",
+          defaultMessage: "I am react element with {variable}",
+        },
+        values,
+      ): React.element
+  );
+  let elementWithPluralForm: {. "itemsCount": int} => React.element = (
     (values: {. "itemsCount": int}) =>
-      React.string(
-        ReactIntlPpxAdaptor.Message.format_to_s(
-          ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
-          [@warning "-45"]
-          ReactIntl.{
-            id: "a2926a901acebbdc606104ceae81dc82",
-            defaultMessage: "{itemsCount, plural, zero {item} one {item} few {items} many {items} other {items}}",
-          },
-          values,
-        ),
-      );
-  let elementWithRichText: {. "a": string => React.element} => React.element =
+      ReactIntlPpxAdaptor.Message.format_to_el(
+        ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
+        [@warning "-45"]
+        ReactIntl.{
+          id: "a2926a901acebbdc606104ceae81dc82",
+          defaultMessage: "{itemsCount, plural, zero {item} one {item} few {items} many {items} other {items}}",
+        },
+        values,
+      ): React.element
+  );
+  let elementWithRichText: {. "a": string => React.element} => React.element = (
     (values: {. "a": string => React.element}) =>
-      React.string(
-        ReactIntlPpxAdaptor.Message.format_to_s(
-          ~list_of_values=[("a", `Component(values##a))],
-          [@warning "-45"]
-          ReactIntl.{
-            id: "c1d9f720d6a89b19f574a7de2bf55f62",
-            defaultMessage: "Some text with <a>link text</a>",
-          },
-          values,
-        ),
-      );
+      ReactIntlPpxAdaptor.Message.format_to_el(
+        ~list_of_values=[("a", `Component(values##a))],
+        [@warning "-45"]
+        ReactIntl.{
+          id: "c1d9f720d6a89b19f574a7de2bf55f62",
+          defaultMessage: "Some text with <a>link text</a>",
+        },
+        values,
+      ): React.element
+  );
   let cellText = (~powerUsersCount) =>
     (
       (
@@ -142,23 +139,18 @@
           "powerUsersCount": int,
         },
       ) =>
-        React.string(
-          ReactIntlPpxAdaptor.Message.format_to_s(
-            ~list_of_values=[
-              (
-                "powerUsersCountString",
-                `Element(values##powerUsersCountString),
-              ),
-              ("powerUsersCount", `Number(values##powerUsersCount)),
-            ],
-            [@warning "-45"]
-            ReactIntl.{
-              id: "f64fa55a351a8fe989d4fe05f15ec260",
-              defaultMessage: {js|{powerUsersCountString} {powerUsersCount, plural, zero {Power users} one {Power user} few {Power users} other {Power users}}|js},
-            },
-            values,
-          ),
-        )
+        ReactIntlPpxAdaptor.Message.format_to_el(
+          ~list_of_values=[
+            ("powerUsersCountString", `Element(values##powerUsersCountString)),
+            ("powerUsersCount", `Number(values##powerUsersCount)),
+          ],
+          [@warning "-45"]
+          ReactIntl.{
+            id: "f64fa55a351a8fe989d4fe05f15ec260",
+            defaultMessage: {js|{powerUsersCountString} {powerUsersCount, plural, zero {Power users} one {Power user} few {Power users} other {Power users}}|js},
+          },
+          values,
+        ): React.element
     ) @@
     {
       "powerUsersCountString": powerUsersCount->RR.int,


### PR DESCRIPTION
There's a need to accessing the values dynamically in the native side, so we can't read values since they are represented as an object and we don't know the keys at runtime and OCaml's doesn't support dynamic field accessors.

Adding a labelled argument feels like a good compromise to not break the interface for others

Introduced the polyvariant `String of string | Number of int | Element of React.element | 
| Component of (string -> React.element)` to be able to represent all kinds of APIs from the ppx. Made it a polyvar to not mess with dependencies/nominality.