### PR TITLE
Migrate ppx from impl to context_free

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,3 @@ watch: ## Watch for the filesystem and rebuild on every change
 .PHONY: test
 test: ## Run all tests
 	$(DUNE) test
-
-.PHONY: test-watch
-test-watch: ## Run all tests in watch mode
-	$(DUNE) test --watch
-
-.PHONY: test-promote
-test-promote: ## Promote all snapshot tests
-	$(DUNE) test --auto-promote

--- a/ppx/MelangeReactIntlPpx.re
+++ b/ppx/MelangeReactIntlPpx.re
@@ -1,33 +1,198 @@
 open Ppxlib;
 
+let parsePayload = (~loc, payload) =>
+  switch (payload) {
+  // Match "message"
+  | PStr([
+      {
+        pstr_desc:
+          Pstr_eval(
+            {pexp_desc: Pexp_constant(Pconst_string(message, _, _)), _} as messageExp,
+            _,
+          ),
+      },
+    ]) => (
+      message,
+      messageExp,
+      None,
+    )
+
+  // Match {msg: "message", desc: "description"} and {desc: "description", msg: "message"}
+  | PStr([
+      {
+        pstr_desc:
+          Pstr_eval(
+            {
+              pexp_desc:
+                Pexp_record(
+                  [
+                    (
+                      {txt: Lident("msg"), _},
+                      {
+                        pexp_desc:
+                          Pexp_constant(Pconst_string(message, _, _)),
+                        _,
+                      } as messageExp,
+                    ),
+                    (
+                      {txt: Lident("desc"), _},
+                      {
+                        pexp_desc:
+                          Pexp_constant(Pconst_string(description, _, _)),
+                        _,
+                      },
+                    ),
+                  ] |
+                  [
+                    (
+                      {txt: Lident("desc"), _},
+                      {
+                        pexp_desc:
+                          Pexp_constant(Pconst_string(description, _, _)),
+                        _,
+                      },
+                    ),
+                    (
+                      {txt: Lident("msg"), _},
+                      {
+                        pexp_desc:
+                          Pexp_constant(Pconst_string(message, _, _)),
+                        _,
+                      } as messageExp,
+                    ),
+                  ],
+                  None,
+                ),
+              _,
+            },
+            _,
+          ),
+      },
+    ]) => (
+      message,
+      messageExp,
+      Some(description),
+    )
+  | _ =>
+    Location.raise_errorf(
+      ~loc,
+      "react-intl-ppx expects the extension payload to be a constant string or a record ({msg: string, desc: string}), it does not work with any other expression types.",
+    )
+  };
+
 class mapper = {
   as _;
   inherit class Ast_traverse.map as super;
   pub! expression = e =>
     switch (e) {
     | {pexp_desc: Pexp_extension(({txt: "intl" | "intl_draft"}, payload))} =>
-      Resolver.makeIntlRecord(~payload, ~loc=e.pexp_loc)
+      let (message, messageExp, description) =
+        parsePayload(~loc=e.pexp_loc, payload);
+      Resolver.makeIntlRecord(
+        message,
+        messageExp,
+        description,
+        ~loc=e.pexp_loc,
+      );
 
     | {
         pexp_desc:
           Pexp_extension(({txt: "intl.s" | "intl_draft.s"}, payload)),
       } =>
-      Resolver.makeString(~payload, ~loc=e.pexp_loc)
+      let (message, messageExp, description) =
+        parsePayload(~loc=e.pexp_loc, payload);
+      Resolver.makeString(~loc=e.pexp_loc, message, messageExp, description);
 
     | {
         pexp_desc:
           Pexp_extension(({txt: "intl.el" | "intl_draft.el"}, payload)),
       } =>
-      Resolver.makeReactElement(~payload, ~loc=e.pexp_loc)
+      let (message, messageExp, description) =
+        parsePayload(~loc=e.pexp_loc, payload);
+      Resolver.makeReactElement(
+        ~loc=e.pexp_loc,
+        message,
+        messageExp,
+        description,
+      );
 
     | _ => super#expression(e)
     };
 };
 
+module IntlRecord = {
+  let extractor = Ast_pattern.(single_expr_payload(__));
+
+  let expression_handler = (~ctxt as _, _) => {
+    let loc = Location.none;
+    [%expr "lola"];
+  };
+
+  let context_free = label =>
+    Context_free.Rule.extension(
+      Extension.V3.declare(
+        label,
+        Extension.Context.expression,
+        extractor,
+        expression_handler,
+      ),
+    );
+};
+
+module IntlString = {
+  let extractor = Ast_pattern.(single_expr_payload(__));
+
+  let expression_handler = (~ctxt as _, _) => {
+    let loc = Location.none;
+    [%expr "lola"];
+  };
+
+  let context_free = label =>
+    Context_free.Rule.extension(
+      Extension.V3.declare(
+        label,
+        Extension.Context.expression,
+        extractor,
+        expression_handler,
+      ),
+    );
+};
+
+module IntlReact = {
+  let extractor = Ast_pattern.(single_expr_payload(__));
+
+  let expression_handler = (~ctxt as _, _) => {
+    let loc = Location.none;
+    [%expr "lola"];
+  };
+
+  let context_free = label =>
+    Context_free.Rule.extension(
+      Extension.V3.declare(
+        label,
+        Extension.Context.expression,
+        extractor,
+        expression_handler,
+      ),
+    );
+};
+
 let structure_mapper = s => (new mapper)#structure(s);
 
-let () =
-  Ppxlib.Driver.register_transformation(
+let () = {
+  Driver.register_transformation(
     ~impl=structure_mapper,
+    "melange-react-intl.ppx-old",
+  );
+  Driver.V2.register_transformation(
+    ~rules=[
+      IntlRecord.context_free("intl"),
+      IntlRecord.context_free("intl_draft"),
+      IntlString.context_free("intl.s"),
+      IntlString.context_free("intl_draft.s"),
+      IntlReact.context_free("intl.el"),
+      IntlReact.context_free("intl_draft.el"),
+    ],
     "melange-react-intl.ppx",
   );
+};

--- a/ppx/MelangeReactIntlPpx.re
+++ b/ppx/MelangeReactIntlPpx.re
@@ -2,14 +2,15 @@ open Ppxlib;
 
 let extractMessage = (~loc, expression) =>
   switch (expression.pexp_desc) {
-  // Match "message"
+  // Match a single string, which represents the "message"
   | Pexp_constant(Pconst_string(message, _, _)) => (
       message,
       expression,
       None,
     )
 
-  // Match {msg: "message", desc: "description"} and {desc: "description", msg: "message"}
+  // Match a record with "msg" and "desc" fields and extract the message and description
+  // Where the order doesn't matter: {msg: "message", desc: "description"} and {desc: "description", msg: "message"}
   | Pexp_record(
       [
         (
@@ -44,7 +45,7 @@ let extractMessage = (~loc, expression) =>
     )
   };
 
-let context_free_expression_tranform = (label, fn) => {
+let context_free_expression_tranform = (label, transform) => {
   let single_expression_payload = Ast_pattern.(single_expr_payload(__));
 
   Context_free.Rule.extension(
@@ -53,10 +54,8 @@ let context_free_expression_tranform = (label, fn) => {
       Extension.Context.expression,
       single_expression_payload,
       (~ctxt as _, expression) => {
-        let loc = expression.pexp_loc;
-        fn(~loc, expression);
-      },
-    ),
+      transform(~loc=expression.pexp_loc, expression)
+    }),
   );
 };
 

--- a/ppx/MelangeReactIntlPpx.re
+++ b/ppx/MelangeReactIntlPpx.re
@@ -1,86 +1,6 @@
 open Ppxlib;
 
-let parsePayload = (~loc, payload) =>
-  switch (payload) {
-  // Match "message"
-  | PStr([
-      {
-        pstr_desc:
-          Pstr_eval(
-            {pexp_desc: Pexp_constant(Pconst_string(message, _, _)), _} as messageExp,
-            _,
-          ),
-      },
-    ]) => (
-      message,
-      messageExp,
-      None,
-    )
-
-  // Match {msg: "message", desc: "description"} and {desc: "description", msg: "message"}
-  | PStr([
-      {
-        pstr_desc:
-          Pstr_eval(
-            {
-              pexp_desc:
-                Pexp_record(
-                  [
-                    (
-                      {txt: Lident("msg"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(message, _, _)),
-                        _,
-                      } as messageExp,
-                    ),
-                    (
-                      {txt: Lident("desc"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(description, _, _)),
-                        _,
-                      },
-                    ),
-                  ] |
-                  [
-                    (
-                      {txt: Lident("desc"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(description, _, _)),
-                        _,
-                      },
-                    ),
-                    (
-                      {txt: Lident("msg"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(message, _, _)),
-                        _,
-                      } as messageExp,
-                    ),
-                  ],
-                  None,
-                ),
-              _,
-            },
-            _,
-          ),
-      },
-    ]) => (
-      message,
-      messageExp,
-      Some(description),
-    )
-  | _ =>
-    Location.raise_errorf(
-      ~loc,
-      "react-intl-ppx expects the extension payload to be a constant string or a record ({msg: string, desc: string}), it does not work with any other expression types.",
-    )
-  };
-
-let extractMessage = (~loc, expression: expression) =>
+let extractMessage = (~loc, expression) =>
   switch (expression.pexp_desc) {
   // Match "message"
   | Pexp_constant(Pconst_string(message, _, _)) => (
@@ -123,46 +43,6 @@ let extractMessage = (~loc, expression: expression) =>
       "react-intl-ppx expects the extension payload to be a constant string or a record ({msg: string, desc: string}), it does not work with any other expression types.",
     )
   };
-
-class mapper = {
-  as _;
-  inherit class Ast_traverse.map as super;
-  pub! expression = e =>
-    switch (e) {
-    | {pexp_desc: Pexp_extension(({txt: "intl" | "intl_draft"}, payload))} =>
-      let (message, messageExp, description) =
-        parsePayload(~loc=e.pexp_loc, payload);
-      Resolver.makeIntlRecord(
-        message,
-        messageExp,
-        description,
-        ~loc=e.pexp_loc,
-      );
-
-    | {
-        pexp_desc:
-          Pexp_extension(({txt: "intl.s" | "intl_draft.s"}, payload)),
-      } =>
-      let (message, messageExp, description) =
-        parsePayload(~loc=e.pexp_loc, payload);
-      Resolver.makeString(~loc=e.pexp_loc, message, messageExp, description);
-
-    | {
-        pexp_desc:
-          Pexp_extension(({txt: "intl.el" | "intl_draft.el"}, payload)),
-      } =>
-      let (message, messageExp, description) =
-        parsePayload(~loc=e.pexp_loc, payload);
-      Resolver.makeReactElement(
-        ~loc=e.pexp_loc,
-        message,
-        messageExp,
-        description,
-      );
-
-    | _ => super#expression(e)
-    };
-};
 
 module IntlRecord = {
   let extractor = Ast_pattern.(single_expr_payload(__));
@@ -227,13 +107,7 @@ module IntlReact = {
     );
 };
 
-let structure_mapper = s => (new mapper)#structure(s);
-
 let () = {
-  Driver.register_transformation(
-    ~impl=structure_mapper,
-    "melange-react-intl.ppx-old",
-  );
   Driver.V2.register_transformation(
     ~rules=[
       IntlRecord.context_free("intl"),

--- a/ppx/MelangeReactIntlPpx.re
+++ b/ppx/MelangeReactIntlPpx.re
@@ -44,78 +44,55 @@ let extractMessage = (~loc, expression) =>
     )
   };
 
-module IntlRecord = {
-  let extractor = Ast_pattern.(single_expr_payload(__));
+let context_free_expression_tranform = (label, fn) => {
+  let single_expression_payload = Ast_pattern.(single_expr_payload(__));
 
-  let expression_handler = (~ctxt as _, expression) => {
-    let loc = expression.pexp_loc;
-    let (messsage, messageExpr, description) =
-      extractMessage(~loc, expression);
-    Resolver.makeIntlRecord(~loc, messsage, messageExpr, description);
-  };
-
-  let context_free = label =>
-    Context_free.Rule.extension(
-      Extension.V3.declare(
-        label,
-        Extension.Context.expression,
-        extractor,
-        expression_handler,
-      ),
-    );
-};
-
-module IntlString = {
-  let extractor = Ast_pattern.(single_expr_payload(__));
-
-  let expression_handler = (~ctxt as _, expression) => {
-    let loc = expression.pexp_loc;
-    let (messsage, messageExpr, description) =
-      extractMessage(~loc, expression);
-    Resolver.makeString(~loc, messsage, messageExpr, description);
-  };
-
-  let context_free = label =>
-    Context_free.Rule.extension(
-      Extension.V3.declare(
-        label,
-        Extension.Context.expression,
-        extractor,
-        expression_handler,
-      ),
-    );
-};
-
-module IntlReact = {
-  let extractor = Ast_pattern.(single_expr_payload(__));
-
-  let expression_handler = (~ctxt as _, expression) => {
-    let loc = expression.pexp_loc;
-    let (messsage, messageExpr, description) =
-      extractMessage(~loc, expression);
-    Resolver.makeReactElement(~loc, messsage, messageExpr, description);
-  };
-
-  let context_free = label =>
-    Context_free.Rule.extension(
-      Extension.V3.declare(
-        label,
-        Extension.Context.expression,
-        extractor,
-        expression_handler,
-      ),
-    );
+  Context_free.Rule.extension(
+    Extension.V3.declare(
+      label,
+      Extension.Context.expression,
+      single_expression_payload,
+      (~ctxt as _, expression) => {
+        let loc = expression.pexp_loc;
+        fn(~loc, expression);
+      },
+    ),
+  );
 };
 
 let () = {
   Driver.V2.register_transformation(
     ~rules=[
-      IntlRecord.context_free("intl"),
-      IntlRecord.context_free("intl_draft"),
-      IntlString.context_free("intl.s"),
-      IntlString.context_free("intl_draft.s"),
-      IntlReact.context_free("intl.el"),
-      IntlReact.context_free("intl_draft.el"),
+      context_free_expression_tranform("intl", (~loc, expression) => {
+        let (messsage, messageExpr, description) =
+          extractMessage(~loc, expression);
+        Resolver.makeIntlRecord(~loc, messsage, messageExpr, description);
+      }),
+      context_free_expression_tranform("intl_draft", (~loc, expression) => {
+        let (messsage, messageExpr, description) =
+          extractMessage(~loc, expression);
+        Resolver.makeIntlRecord(~loc, messsage, messageExpr, description);
+      }),
+      context_free_expression_tranform("intl.s", (~loc, expression) => {
+        let (messsage, messageExpr, description) =
+          extractMessage(~loc, expression);
+        Resolver.makeString(~loc, messsage, messageExpr, description);
+      }),
+      context_free_expression_tranform("intl_draft.s", (~loc, expression) => {
+        let (messsage, messageExpr, description) =
+          extractMessage(~loc, expression);
+        Resolver.makeString(~loc, messsage, messageExpr, description);
+      }),
+      context_free_expression_tranform("intl.el", (~loc, expression) => {
+        let (messsage, messageExpr, description) =
+          extractMessage(~loc, expression);
+        Resolver.makeReactElement(~loc, messsage, messageExpr, description);
+      }),
+      context_free_expression_tranform("intl_draft.el", (~loc, expression) => {
+        let (messsage, messageExpr, description) =
+          extractMessage(~loc, expression);
+        Resolver.makeIntlRecord(~loc, messsage, messageExpr, description);
+      }),
     ],
     "melange-react-intl.ppx",
   );

--- a/ppx/MelangeReactIntlPpx.re
+++ b/ppx/MelangeReactIntlPpx.re
@@ -1,5 +1,6 @@
 open Ppxlib;
 
+/* Given an expression, extract the right shape from a string or a record. This could be refactored into Ast_pattern. */
 let extractMessage = (~loc, expression) =>
   switch (expression.pexp_desc) {
   // Match a single string, which represents the "message"
@@ -46,6 +47,7 @@ let extractMessage = (~loc, expression) =>
   };
 
 let context_free_expression_tranform = (label, transform) => {
+  /* This pattern matches any single expression under a PStr */
   let single_expression_payload = Ast_pattern.(single_expr_payload(__));
 
   Context_free.Rule.extension(

--- a/ppx/MelangeReactIntlPpx.re
+++ b/ppx/MelangeReactIntlPpx.re
@@ -92,7 +92,7 @@ let () = {
       context_free_expression_tranform("intl_draft.el", (~loc, expression) => {
         let (messsage, messageExpr, description) =
           extractMessage(~loc, expression);
-        Resolver.makeIntlRecord(~loc, messsage, messageExpr, description);
+        Resolver.makeReactElement(~loc, messsage, messageExpr, description);
       }),
     ],
     "melange-react-intl.ppx",

--- a/ppx/Resolver.re
+++ b/ppx/Resolver.re
@@ -142,20 +142,17 @@ let makeReactElement = (~loc, message, messageExp, description) => {
   let variables = simpleVariables @ pluralVariables @ richTextVariables;
 
   switch (variables) {
-  | [] =>
-    [%expr React.string(ReactIntlPpxAdaptor.Message.to_s([%e recordExp]))]
+  | [] => [%expr ReactIntlPpxAdaptor.Message.to_s([%e recordExp])]
   | variables =>
     let valuesType = variables |> makeValuesType(~loc);
     let listAsValues = makeValuesAsList(~loc, variables);
     [%expr
      (
        (values: Js.t([%t valuesType])) =>
-         React.string(
-           ReactIntlPpxAdaptor.Message.format_to_s(
-             ~list_of_values=[%e listAsValues],
-             [%e recordExp],
-             values,
-           ),
+         ReactIntlPpxAdaptor.Message.format_to_s(
+           ~list_of_values=[%e listAsValues],
+           [%e recordExp],
+           values,
          )
      )];
   };

--- a/ppx/Resolver.re
+++ b/ppx/Resolver.re
@@ -1,5 +1,4 @@
 open Ppxlib;
-module Builder = Ppxlib.Ast_builder.Default;
 
 let makeId = (~description="", message) =>
   message ++ "|" ++ description |> Digest.string |> Digest.to_hex;
@@ -9,69 +8,14 @@ let tryUnescape = s =>
   | Scanf.Scan_failure(_err) => s
   };
 
-let warning_45 = (~loc) =>
-  Builder.attribute(
-    ~loc,
-    ~name={Location.loc, txt: "warning"},
-    ~payload=
-      PStr([Builder.pstr_eval(~loc, Builder.estring(~loc, "-45"), [])]),
-  );
-
 let makeIntlRecord = (~loc, message, messageExp, description) => {
   let id = message |> tryUnescape |> makeId(~description?);
   let idExp = Ast_helper.Exp.constant(Pconst_string(id, loc, None));
-  let expr = [%expr
-    ReactIntl.{id: [%e idExp], defaultMessage: [%e messageExp]}
-  ];
-  {...expr, pexp_attributes: [warning_45(~loc)]};
+  %expr
+  [@warning "-45"]
+  ReactIntl.{id: [%e idExp], defaultMessage: [%e messageExp]};
 };
 
-let makeValuesAsList = (~loc, variables) => {
-  let list_of_expr =
-    variables
-    |> List.map(((label, type_)) => {
-         let key = Ast_helper.Exp.constant(Pconst_string(label, loc, None));
-         /* Here we read the field from the Js.t `values` with `##` (values##variable_name) */
-         let access_values_object =
-           Ast_helper.Exp.apply(
-             Ast_helper.Exp.ident({txt: Lident("##"), loc}),
-             [
-               (Nolabel, Ast_helper.Exp.ident({txt: Lident("values"), loc})),
-               (Nolabel, Ast_helper.Exp.ident({txt: Lident(label), loc})),
-             ],
-           );
-         let value =
-           switch (type_.ptyp_desc) {
-           | Ptyp_constr({txt: Lident("string")}, []) =>
-             [%expr `String([%e access_values_object])]
-           | Ptyp_constr({txt: Lident("int")}, []) =>
-             [%expr `Number([%e access_values_object])]
-           | Ptyp_constr({txt: Ldot(Lident("React"), "element")}, []) =>
-             [%expr `Element([%e access_values_object])]
-           | Ptyp_arrow(_, core_type_arg, core_type_return) =>
-             switch (core_type_arg.ptyp_desc, core_type_return.ptyp_desc) {
-             | (
-                 Ptyp_constr({txt: Lident("string")}, []),
-                 Ptyp_constr({txt: Ldot(Lident("React"), "element")}, []),
-               ) =>
-               [%expr `Component([%e access_values_object])]
-             | _ =>
-               [%expr
-                [%ocaml.error
-                  "melange-react-intl: Unsupported rich text variable type, only string => React.element is supported"
-                ]]
-             }
-           | _ =>
-             [%expr
-              [%ocaml.error
-                "melange-react-intl: Unsupported variable type, only `string`, `int`, `React.element` or `string => React.element` are supported"
-              ]]
-           };
-         [%expr ([%e key], [%e value])];
-       });
-
-  [%expr [[%e Ast_helper.Exp.tuple(list_of_expr)]]];
-};
 let makeValuesType = (~loc, fields: list((string, core_type))): core_type => {
   let objectFields =
     fields
@@ -107,20 +51,17 @@ let makeString = (~loc, message, messageExp, description) => {
   let variables = simpleVariables @ pluralVariables;
 
   switch (variables) {
-  | [] => [%expr ReactIntlPpxAdaptor.Message.to_s([%e recordExp])]
+  | [] =>
+    %expr
+    ReactIntlPpxAdaptor.Message.to_s([%e recordExp])
   | variables =>
     let valuesType = variables |> makeValuesType(~loc);
-    let listAsValues = makeValuesAsList(~loc, variables);
-    [%expr
-     (
-       (values: Js.t([%t valuesType])) => (
-         ReactIntlPpxAdaptor.Message.format_to_s(
-           ~list_of_values=[%e listAsValues],
-           [%e recordExp],
-           values,
-         ): string
-       )
-     )];
+    %expr
+    (
+      (values: Js.t([%t valuesType])) => (
+        ReactIntlPpxAdaptor.Message.format_to_s([%e recordExp], values): string
+      )
+    );
   };
 };
 
@@ -142,18 +83,17 @@ let makeReactElement = (~loc, message, messageExp, description) => {
   let variables = simpleVariables @ pluralVariables @ richTextVariables;
 
   switch (variables) {
-  | [] => [%expr ReactIntlPpxAdaptor.Message.to_s([%e recordExp])]
+  | [] =>
+    %expr
+    React.string(ReactIntlPpxAdaptor.Message.to_s([%e recordExp]))
   | variables =>
     let valuesType = variables |> makeValuesType(~loc);
-    let listAsValues = makeValuesAsList(~loc, variables);
-    [%expr
-     (
-       (values: Js.t([%t valuesType])) =>
-         ReactIntlPpxAdaptor.Message.format_to_s(
-           ~list_of_values=[%e listAsValues],
-           [%e recordExp],
-           values,
-         )
-     )];
+    %expr
+    (
+      (values: Js.t([%t valuesType])) =>
+        React.string(
+          ReactIntlPpxAdaptor.Message.format_to_s([%e recordExp], values)
+        )
+    );
   };
 };

--- a/ppx/dune
+++ b/ppx/dune
@@ -2,8 +2,6 @@
  (name MelangeReactIntlPpx)
  (public_name melange-react-intl.ppx)
  (libraries ppxlib re)
- (flags
-  (:standard -w -9))
  (kind ppx_rewriter)
  (preprocess
   (pps ppxlib.metaquot)))

--- a/ppx/dune
+++ b/ppx/dune
@@ -1,10 +1,7 @@
 (library
  (name MelangeReactIntlPpx)
  (public_name melange-react-intl.ppx)
- (libraries
-  ppxlib
-  reason
-  re) 
+ (libraries ppxlib re)
  (flags
   (:standard -w -9))
  (kind ppx_rewriter)

--- a/ppx/dune
+++ b/ppx/dune
@@ -2,6 +2,8 @@
  (name MelangeReactIntlPpx)
  (public_name melange-react-intl.ppx)
  (libraries ppxlib re)
+ (flags
+  (:standard -w -9))
  (kind ppx_rewriter)
  (preprocess
   (pps ppxlib.metaquot)))

--- a/test/ppx/params.t
+++ b/test/ppx/params.t
@@ -9,7 +9,6 @@ Basic case
     (values: {. "maxLength": React.element}) =>
       React.string(
         ReactIntlPpxAdaptor.Message.format_to_s(
-          ~list_of_values=[("maxLength", `Element(values##maxLength))],
           [@warning "-45"]
           ReactIntl.{
             id: "52d92c9e4920f7e245381fad58360708",
@@ -44,12 +43,6 @@ With plural
         },
       ) => (
         ReactIntlPpxAdaptor.Message.format_to_s(
-          ~list_of_values=[
-            (
-              ("listName", `String(values##listName)),
-              ("keywordsCount", `Number(values##keywordsCount)),
-            ),
-          ],
           [@warning "-45"]
           ReactIntl.{
             id: "0df6b0b4831df770629c8980275ccf00",

--- a/test/ppx/simple.t/run.t
+++ b/test/ppx/simple.t/run.t
@@ -73,7 +73,6 @@
   let stringWithVariable: {. "variable": string} => string =
     (values: {. "variable": string}) => (
       ReactIntlPpxAdaptor.Message.format_to_s(
-        ~list_of_values=[("variable", `String(values##variable))],
         [@warning "-45"]
         ReactIntl.{
           id: "4271c9d35b2eac4fca6faf3e2eeb6019",
@@ -85,7 +84,6 @@
   let stringWithPluralForm: {. "itemsCount": int} => string =
     (values: {. "itemsCount": int}) => (
       ReactIntlPpxAdaptor.Message.format_to_s(
-        ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
         [@warning "-45"]
         ReactIntl.{
           id: "a2926a901acebbdc606104ceae81dc82",
@@ -98,7 +96,6 @@
     (values: {. "variable": React.element}) =>
       React.string(
         ReactIntlPpxAdaptor.Message.format_to_s(
-          ~list_of_values=[("variable", `Element(values##variable))],
           [@warning "-45"]
           ReactIntl.{
             id: "ac400e3c977990cd86a6981ad7eef8cd",
@@ -111,7 +108,6 @@
     (values: {. "itemsCount": int}) =>
       React.string(
         ReactIntlPpxAdaptor.Message.format_to_s(
-          ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
           [@warning "-45"]
           ReactIntl.{
             id: "a2926a901acebbdc606104ceae81dc82",
@@ -124,7 +120,6 @@
     (values: {. "a": string => React.element}) =>
       React.string(
         ReactIntlPpxAdaptor.Message.format_to_s(
-          ~list_of_values=[("a", `Component(values##a))],
           [@warning "-45"]
           ReactIntl.{
             id: "c1d9f720d6a89b19f574a7de2bf55f62",
@@ -144,15 +139,6 @@
       ) =>
         React.string(
           ReactIntlPpxAdaptor.Message.format_to_s(
-            ~list_of_values=[
-              (
-                (
-                  "powerUsersCountString",
-                  `Element(values##powerUsersCountString),
-                ),
-                ("powerUsersCount", `Number(values##powerUsersCount)),
-              ),
-            ],
             [@warning "-45"]
             ReactIntl.{
               id: "f64fa55a351a8fe989d4fe05f15ec260",


### PR DESCRIPTION
Resolves https://github.com/ahrefs/melange-react-intl/issues/27

I moved `parsePayload` from the `Resolve` module to the ppx file, because is the one that hooks into the AST and extracts information and felt more relevant there.